### PR TITLE
Change root directory of support files to $RUBYMOTION_ANDROID_SDK

### DIFF
--- a/lib/motion/project/gradle.erb
+++ b/lib/motion/project/gradle.erb
@@ -8,7 +8,7 @@ task generateDependencies(type: Jar) {
 }
 
 repositories {
-  def androidHome = System.getenv("ANDROID_HOME")
+  def androidHome = System.getenv("RUBYMOTION_ANDROID_SDK")
   maven {
     url "$androidHome/extras/android/m2repository/"
   }


### PR DESCRIPTION
I tried this out in our current project, and it worked great! Bye-bye motion-maven :)

The only thing that didn't work out of the box was including the Android support libraries. I had installed `Extras/Android Support Repository` per the instructions, but the generated `.gradle` file was using `$ANDROID_HOME` as the root directory for the support files. The RubyMotion setup instructions do not mention this variable, and it's possible that many users won't have it. 

However, we do have `$RUBYMOTION_ANDROID_SDK` set, and by using that instead of `$ANDROID_HOME`, the support libs were installed.
