### PR TITLE
space between rake and clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,6 @@ task:
 $ [bundle exec] rake gradle:install
 ```
 
-After a `rake:clean:all` you will need to run the install task agin.
+After a `rake clean:all` you will need to run the install task agin.
 
 That’s all.


### PR DESCRIPTION
Theres a space missing in `rake:clean:all`, should be `rake clean:all`
