### PR TITLE
Support aars with embedded jar dependencies.

### DIFF
--- a/lib/motion/project/gradle.rb
+++ b/lib/motion/project/gradle.rb
@@ -97,6 +97,10 @@ module Motion::Project
       aars_dependendies = Dir[File.join(GRADLE_ROOT, 'aar/*')]
       aars_dependendies.each do |dependency|
         vendor_options = {:jar => File.join(dependency, 'classes.jar')}
+        # libs/*.jar may contain dependencies, let's vendor them
+        Dir[File.join(dependency, 'libs/*.jar')].each do |internal_dependancy|
+          @config.vendor_project({:jar => internal_dependancy})
+        end
 
         res = File.join(dependency, 'res')
         if File.exist?(res)


### PR DESCRIPTION
Sometimes _.aar files comes with their own dependency jars which are stored in libs/_.jar.  This will vendor those embedded dudes.   

https://github.com/HipByte/motion-gradle/issues/15

(support-v4 after version 19 is like this)
